### PR TITLE
Fix template path for hook

### DIFF
--- a/pscartbanner.php
+++ b/pscartbanner.php
@@ -173,6 +173,6 @@ class PsCartBanner extends Module
             'bannerBorderColor' => Configuration::get(static::CONFIG_BANNER_BORDER_COLOR),
         ]);
 
-        return $this->display(__FILE__, '/views/templates/hook/displayContentWrapperTop.tpl');
+        return $this->display(__FILE__, 'views/templates/hook/displayContentWrapperTop.tpl');
     }
 }


### PR DESCRIPTION
Depending on opendir restrictions, when using absolute paths for templates, the following error may be thrown:

`file_exists(): open_basedir restriction in effect. File(/views/templates/hook/displayContentWrapperTop.tpl) is not within the allowed path(s): (/var/webroot:/tmp:/usr/share/php:/usr/share/pear) in /var/webroot/classes/module/Module.php on line 2509`

This pull request fixes the PHP warning described above that may arise when fetching a template HTML content.

Tested on PrestaShop 1.7.8.7 and 1.7.8.9.
